### PR TITLE
Tweaking size of warnings

### DIFF
--- a/public/bootstrap/css/bootstrap.css
+++ b/public/bootstrap/css/bootstrap.css
@@ -5772,3 +5772,11 @@ a.badge:hover {
 .affix {
   position: fixed;
 }
+
+
+/* Custom Styles */
+
+.ng-scope .comparison h2{
+  font-size: 20px;
+	margin-top: 0px;
+}


### PR DESCRIPTION
I didn't see a specific stylesheet that overrode the Bootstrap defaults, so I'm making this change here. Feel free to move elsewhere.
